### PR TITLE
Merge GH-278  fix branch in to dev-1.5.4 branch

### DIFF
--- a/src/ws/app/wsmodules/web_scraper.py
+++ b/src/ws/app/wsmodules/web_scraper.py
@@ -41,9 +41,35 @@ def scrape_website():
     """Main function of module calls all sub-functions"""
     logger.info("--- Starting web_scraper module ---")
     logger.info("Extracting BS4 objects")
-    ogre_object = get_bs_object(FLATS_OGRE)
-    logger.info("Building non-duplicate URL list from BS4 objects")
-    valid_msg_urls = find_single_page_urls(ogre_object)
+    # ogre_object = get_bs_object(FLATS_OGRE)
+    # logger.info("Building non-duplicate URL list from BS4 objects")
+    # valid_msg_urls = find_single_page_urls(ogre_object)
+    
+    # Original code with bug
+    # page = requests.get("https://www.ss.lv/lv/real-estate/flats/ogre-and-reg/ogre/sell/")
+    # bs_ogre_object = BeautifulSoup(page.content, "html.parser")
+    # valid_msg_urls = find_single_page_urls(bs_ogre_object)
+    
+    # New static way of extracting data from first three pages
+    # TODO: make page count extraction dynamic
+    page_one = requests.get("https://www.ss.lv/lv/real-estate/flats/ogre-and-reg/ogre/sell/")
+    page_two = requests.get("https://www.ss.lv/lv/real-estate/flats/ogre-and-reg/ogre/sell/page2.html")
+    page_three = requests.get("https://www.ss.lv/lv/real-estate/flats/ogre-and-reg/ogre/sell/page3.html")
+    
+    # Error handling behavior by ss.lv
+    # If non existing page requested for example https://www.ss.lv/lv/real-estate/flats/ogre-and-reg/ogre/sell/page4.html
+    # it rederacts to first page https://www.ss.lv/lv/real-estate/flats/ogre-and-reg/ogre/sell/page.html
+
+    page_one_bs_obj = BeautifulSoup(page_one.content, "html.parser")
+    page_two_bs_obj = BeautifulSoup(page_two.content, "html.parser")
+    page_three_bs_obj = BeautifulSoup(page_three.content, "html.parser")
+    
+    page_one_msg_urls = find_single_page_urls(page_one_bs_obj)
+    page_two_msg_urls = find_single_page_urls(page_two_bs_obj)
+    page_three_msg_urls = find_single_page_urls(page_three_bs_obj)
+    valid_msg_urls = page_one_msg_urls +  page_two_msg_urls + page_three_msg_urls
+
+
     logger.info(f"Found {str(len(valid_msg_urls))} parsable message URLs")
     logger.info(
         "Extracting data for Ogre city apartments for sell task and saving as Ogre-raw-data-report.txt")

--- a/src/ws/app/wsmodules/web_scraper.py
+++ b/src/ws/app/wsmodules/web_scraper.py
@@ -67,7 +67,14 @@ def scrape_website():
     page_one_msg_urls = find_single_page_urls(page_one_bs_obj)
     page_two_msg_urls = find_single_page_urls(page_two_bs_obj)
     page_three_msg_urls = find_single_page_urls(page_three_bs_obj)
-    valid_msg_urls = page_one_msg_urls +  page_two_msg_urls + page_three_msg_urls
+    combined_urls = page_one_msg_urls + page_two_msg_urls + page_three_msg_urls
+    # Since currently there is no dynamic page cound extraction avilable 
+    # curent behavior of ss.lv if you request none existing page it redirects to
+    # first page current quick fix is to remove duplicate entries because of scenario 
+    # if page 3 is missing an you have requested it will gra  urls from first page and 
+    # it will end up with duplicate entries
+    valid_msg_urls = list(set(combined_urls))
+
 
 
     logger.info(f"Found {str(len(valid_msg_urls))} parsable message URLs")


### PR DESCRIPTION
What will be impacted:
- Before merge test was done legacy scrape job lambda for Ogre city ONLY for first page cron trigger was disabled
- Cron job was getting triggered 00:15 UTC (Riga time UTC+3 01:15) TBC
- Details of lambda: region: us-east-1. function name : test-docker-lambda
-   from task scheduler module local job is triggered at 0:30 
    schedule.every().day.at("00:30").do(execute_ogre_task)
-  Email arrives at (02:35AM )

First test failover use local scraper when cloud lambda srape file is not available in S3 - success
- Ogre City Apartments for sale from ss.lv webscraperv1.5.4 20240720_0035
- Last 3 days 
2024-07-18 : TSA [A]: 30 LA TBL [B]: 30 AinB [C]: 26 KLAT A notin B [D]: 4 NewAds, B notin A [E]: 4 RM from LAT
LA TBL rows: 30 RA TBL rows: 1562
LA TBL rows: 30 RA TBL rows: 1562
2024-07-19 : TSA [A]: 30 LA TBL [B]: 30 AinB [C]: 28 KLAT A notin B [D]: 2 NewAds, B notin A [E]: 2 RM from LAT
LA TBL rows: 30 RA TBL rows: 1564
LA TBL rows: 30 RA TBL rows: 1564
After stopping cron trigger for lambda
2024-07-20 : TSA [A]: 30 LA TBL [B]: 30 AinB [C]: 27 KLAT A notin B [D]: 3 NewAds, B notin A [E]: 3 RM from LAT
LA TBL rows: 30 RA TBL rows: 1567

- yesterday  66 ads where listed
-  sleep in local ws is 5 sec between each ad url - this means thatscrape job should have lasted 5x66/60 = 5.5 min
- CI stage will last at least 5.5 min + curent times
- CD stage will last 5.5 min as well

