### PR TITLE
Tune health check interval and request limit

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
         condition: service_healthy
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:8000/health || exit 1"]
-      interval: 30s
+      interval: 60s
       timeout: 10s
       start_period: 15s
       retries: 3

--- a/src/ws/Dockerfile
+++ b/src/ws/Dockerfile
@@ -15,15 +15,16 @@ COPY database.ini /
 
 COPY ./app /app
 
-HEALTHCHECK --interval=30s --timeout=10s --retries=3 \
+HEALTHCHECK --interval=60s --timeout=10s --retries=3 \
   CMD curl -f http://localhost:8000/health || exit 1
 
 # Uvicorn configuration with memory leak prevention
 # --host 0.0.0.0: Bind to all network interfaces (allows external connections)
 # --port 8000: Listen on port 8000
 # --workers 2: Run 2 worker processes (provides redundancy and load distribution)
-# --limit-max-requests 30: Restart worker after handling 30 requests (prevents OOM on 2GB RAM instance)
-#                          With ~24MB leak per request: 101MB + (24MB × 30) = 821MB per worker
-#                          Total with 2 workers: ~1.64GB + 300MB OS = 1.94GB (safe for 2GB instance)
+# --limit-max-requests 1000: Restart worker after 1000 requests (prevents OOM on 2GB RAM instance)
+#                            Health checks (~1440/worker/day) are lightweight and don't leak memory.
+#                            Only /run-task requests leak ~24MB each. At 1000 limit, workers restart
+#                            roughly every 8 hours, balancing OOM safety with minimal churn.
 # --timeout-keep-alive 5: Close keep-alive connections after 5 seconds (frees up resources)
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "2", "--limit-max-requests", "30", "--timeout-keep-alive", "5"]
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "2", "--limit-max-requests", "1000", "--timeout-keep-alive", "5"]


### PR DESCRIPTION
## Summary
- Increase uvicorn `--limit-max-requests` from 30 to 1000 — health checks don't cause the memory leak, so workers were restarting ~48 times/day unnecessarily
- Increase ws health check interval from 30s to 60s (Dockerfile + docker-compose.yml) to halve health check traffic

## Context
With `--limit-max-requests 30` and health checks every 30s, each worker hit the limit in ~15 minutes purely from health checks. The OOM protection only matters for `/run-task` requests (~24MB leak each), which run once per day.

## Test plan
- [ ] Deploy to staging and verify worker restart frequency drops (check logs for "Maximum request limit" messages)
- [ ] Confirm `/health` endpoint still responds within 60s interval
- [ ] Confirm `/run-task/ogre` pipeline completes without worker restart mid-execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)