### PR TITLE
(cicd): bump GH Actions to Node.js 24 compatible versions + add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 5

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Set up Python 3.9
         uses: actions/setup-python@v6
         with:
@@ -35,7 +35,7 @@ jobs:
           coverage xml -o coverage.xml
         continue-on-error: true
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           name: coverage-report
           files: coverage.xml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Set up SSH key
         run: |
           echo "${{ secrets.PROD_M5_EC2_PRIVATE_KEY }}" > private_key

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.branch }}
       - name: Set up Python 3.9
@@ -33,7 +33,7 @@ jobs:
           coverage xml -o coverage.xml
         continue-on-error: true
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           name: coverage-report
           files: coverage.xml
@@ -49,7 +49,7 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     steps:
       - name: Check out code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.branch }}
       - name: Create database.ini
@@ -100,7 +100,7 @@ jobs:
     needs: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.branch }}
       - name: Set up SSH key


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` v5 → v6 in both `main.yml` and `staging.yml` (4 occurrences total)
- Bump `codecov/codecov-action` v5 → v6 in both workflows — this resolves the Node.js 20 deprecation warning seen in staging logs (`actions/github-script` is a transitive dep of codecov-action v5)
- Add `.github/dependabot.yml` for monthly auto-PRs on action version bumps going forward

## Why now
GitHub forces Node.js 24 as default on **June 2, 2026** (~4 weeks). After that date, actions still on Node.js 20 may fail silently. This is a hard deadline, not a nice-to-have.

## Test plan
- [ ] Verify no Node.js 20 deprecation warning appears in next workflow run
- [ ] Confirm `Deploy to Production` and `Deploy to Staging` jobs pass after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)