### PR TITLE
(cicd): bump Python 3.10 to 3.11 in ws and ts Dockerfiles

### DIFF
--- a/src/ts/Dockerfile
+++ b/src/ts/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM python:3.10-slim-bookworm
+FROM python:3.11-slim-bookworm
 
 WORKDIR /app
 

--- a/src/ws/Dockerfile
+++ b/src/ws/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim-bookworm
+FROM python:3.11-slim-bookworm
 
 # Install curl for HEALTHCHECK
 RUN apt-get update && \


### PR DESCRIPTION
## Summary
- `src/ws/Dockerfile`: `python:3.10-slim-bookworm` → `python:3.11-slim-bookworm`
- `src/ts/Dockerfile`: `python:3.10-slim-bookworm` → `python:3.11-slim-bookworm`

Closes #396.

## Context
Python 3.8 (EOL) was bumped to 3.10 as part of dev-1.5.11 (commit `63e2f6a`). Issue #396 targets 3.11 — this completes that upgrade. The `slim-bookworm` base image stays the same, only the Python minor version changes.

## Test plan
- [ ] Staging deploy passes (containers build and start healthy)
- [ ] No import or runtime errors in ws and ts container logs after startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)