### PR TITLE
(fix): fix month label, duplicate DB print, and cryptic report abbreviations

### DIFF
--- a/src/ws/app/wsmodules/db_worker.py
+++ b/src/ws/app/wsmodules/db_worker.py
@@ -68,11 +68,9 @@ def db_worker_main() -> None:
         logger.warning("DataFrame is empty. Skipping processing.")
         return  # Exit gracefully instead of crashing
 
-    df = load_csv_to_df("cleaned-sorted-df.csv")
     # Extract new and still listed message url hashes
     todays_url_hashes = extract_url_hashes_from_df(df)
     still_listed_table_url_hashes = extract_listed_url_hashes_from_db()
-    save_table_row_counts()
     # Sorting all hashes to 3 categories (new, still_listed, to_remove)
     hashe_categories = compare_df_to_db_hashes(
         todays_url_hashes, still_listed_table_url_hashes
@@ -105,7 +103,7 @@ def save_table_row_counts() -> None:
     listed_tbl_hashes = extract_listed_url_hashes_from_db()
     removed_tbl_row_cnt = list_rows_in_removed_table()
     db_tbl_row_counts = (
-        f"LA TBL rows: {len(listed_tbl_hashes)} RA TBL rows: {removed_tbl_row_cnt}"
+        f"Active listings in DB: {len(listed_tbl_hashes)} | Removed ads in DB: {removed_tbl_row_cnt}"
     )
     with open("scraped_and_removed.txt", "a") as file:
         file.write(db_tbl_row_counts + "\n")
@@ -256,10 +254,9 @@ def compare_df_to_db_hashes(df_hashes: list, db_hashes: list) -> list:
     today = datetime.today()
     formatted_date = today.strftime("%Y-%m-%d")
     todays_result = (
-        f"{formatted_date} : TSA [A]: {len(df_hashes)} "
-        f"LA TBL [B]: {len(db_hashes)} AinB [C]: {len(existing_ads)} KLAT "
-        f"A notin B [D]: {len(new_ads)} NewAds, B notin A [E]: "
-        f"{len(removed_ads)} RM from LAT"
+        f"{formatted_date}: Scraped today: {len(df_hashes)} | "
+        f"In DB: {len(db_hashes)} | Unchanged: {len(existing_ads)} | "
+        f"New ads: {len(new_ads)} | Removed: {len(removed_ads)}"
     )
     with open("scraped_and_removed.txt", "a") as file:
         file.write(todays_result + "\n")  # Add a newline for clarity

--- a/src/ws/app/wsmodules/df_cleaner.py
+++ b/src/ws/app/wsmodules/df_cleaner.py
@@ -295,8 +295,8 @@ def split_pub_dates_by_month(data: dict, months: list) -> list:
             if curr_month == month:
                 curr_dict[key_date] = add_count
         list_of_dicts.append(curr_dict)
-    for month_dict in list_of_dicts:
-        month_line = "\n--- Month: ---"
+    for month, month_dict in zip(months, list_of_dicts):
+        month_line = f"\n--- Month: {month} ---"
         pub_date_report_lines.append(month_line)
         sorted_month_dict = dict(sorted(month_dict.items()))
         for k, v in sorted_month_dict.items():


### PR DESCRIPTION
## Summary
Three email report fixes from `todo_refactor_email_report.md`:

**BUG-1** — `df_cleaner.py:299`: Month section header was hardcoded as `--- Month: ---` with no value. Fixed by switching the loop to `zip(months, list_of_dicts)` and interpolating the month value: `--- Month: 04.2026 ---`.

**BUG-2** — `db_worker.py`: `save_table_row_counts()` was called twice per run (before and after processing), causing each day's DB row counts to appear twice in the email. Removed the premature first call. Also removed the duplicate `load_csv_to_df()` call that followed the empty-check guard.

**UX-4 Option A** — `db_worker.py`: Replaced internal abbreviations in `scraped_and_removed.txt` output with plain English:
- Before: `2026-04-22 : TSA [A]: 45 LA TBL [B]: 47 AinB [C]: 44 KLAT A notin B [D]: 1 NewAds, B notin A [E]: 3 RM from LAT`
- After: `2026-04-22: Scraped today: 45 | In DB: 47 | Unchanged: 44 | New ads: 1 | Removed: 3`

## Files changed
- `src/ws/app/wsmodules/df_cleaner.py`
- `src/ws/app/wsmodules/db_worker.py`

## Test plan
- [ ] Verify month section headers show `--- Month: MM.YYYY ---` in next email report
- [ ] Verify each date appears only once in the DB sync log section (no duplicate row-count lines)
- [ ] Verify DB sync log lines use plain English labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)