### PR TITLE
(feat): add report date header, total listing count, and [NEW] marker to email report

### DIFF
--- a/src/ws/app/wsmodules/df_cleaner.py
+++ b/src/ws/app/wsmodules/df_cleaner.py
@@ -210,7 +210,17 @@ def create_email_body(clean_data_frame, file_name: str) -> None:
     log.info(f"Started creation of {file_name} file")
     rc_column_dtype = clean_data_frame['Room_count'].dtype
     log.info(f"DataFrame Room_count column dtype: {rc_column_dtype}")
+
+    today_str = datetime.today().strftime('%d.%m.%Y')
+    total_ads = len(clean_data_frame)
+
     email_body_txt = []
+    # UX-1: report date header
+    email_body_txt.append(f"=== Ogre Apartment Report — {today_str} ===")
+    # UX-7: total active listing count summary
+    email_body_txt.append(f"Total active listings: {total_ads}")
+    email_body_txt.append("")
+
     for room_count in range(4):
         room_count_str = str(room_count + 1)
         section_line = str(room_count_str + " room apartment segment:")
@@ -232,6 +242,8 @@ def create_email_body(clean_data_frame, file_name: str) -> None:
             rooms_str = row['Room_count']
             street_str = row['Street']
             pub_date_str = row['Pub_date']
+            # UX-3: mark listings published today
+            new_marker = " [NEW]" if pub_date_str == today_str else ""
             report_line = "  " + str(rooms_str) + "     " + \
                           str(floor_str) + "    " + \
                           str(sqm_str) + "   " + \
@@ -239,7 +251,7 @@ def create_email_body(clean_data_frame, file_name: str) -> None:
                           str(sqm_price) + "   " + \
                           str(street_str) + "   " + \
                           str(pub_date_str) + " " + \
-                          str(url_str)
+                          str(url_str) + new_marker
             email_body_txt.append(report_line)
     log.info(f"Completed creation of {file_name} file")
     save_text_report_to_file(email_body_txt, file_name)


### PR DESCRIPTION
## Summary
Three UX improvements to the daily email report (`df_cleaner.py` — `create_email_body()`):

**UX-1 — Report date header**
Prepends `=== Ogre Apartment Report — DD.MM.YYYY ===` so the reader immediately knows which day's data they are looking at. Previously there was no date anywhere in the listing section.

**UX-7 — Total active listings count**
Adds `Total active listings: N` line directly below the header. Previously the reader had to sum the per-segment counts from the price stats table at the bottom.

**UX-3 — [NEW] marker on today's listings**
Appends `[NEW]` to any listing row whose `Pub_date` matches today's date, making newly listed ads immediately visible within each segment. This is the most actionable data point in a daily report.

## What the report now looks like at the top
```
=== Ogre Apartment Report — 02.05.2026 ===
Total active listings: 44

1 room apartment segment:
[Rooms, Floor, Size, Price, SQM Price, Apartment Street, Pub_date,  URL]
  1     2/2    23.4   14000    598.29   Zinību 6   01.04.2026 https://... 
  1     1/5    29.0   30900    1065.52  Mālkalnes prospekts 24  02.05.2026 https://... [NEW]
```

## Files changed
- `src/ws/app/wsmodules/df_cleaner.py` — `create_email_body()` only

## Test plan
- [ ] Verify report header shows today's date in DD.MM.YYYY format
- [ ] Verify total listing count matches row count in `cleaned-sorted-df.csv`
- [ ] Verify `[NEW]` appears only on rows where `Pub_date` equals today's date
- [ ] Verify no `[NEW]` markers on older listings

🤖 Generated with [Claude Code](https://claude.com/claude-code)