### PR TITLE
(fix): correct avg_price calculation and include all room segments in email report

### DIFF
--- a/src/ws/app/wsmodules/analytics.py
+++ b/src/ws/app/wsmodules/analytics.py
@@ -127,7 +127,7 @@ def calculate_price_stats(price_data: dict) -> dict:
         ad_count = str(len(prices))
         min_price = str(min(prices))
         max_price = str(max(prices))
-        avg_price = str((min(prices) + max(prices)) / 2)
+        avg_price = str(round(sum(prices) / len(prices), 2))
         price_range = str(max(prices) - min(prices))
         data_values.append(ad_count)
         data_values.append(min_price)

--- a/src/ws/app/wsmodules/df_cleaner.py
+++ b/src/ws/app/wsmodules/df_cleaner.py
@@ -221,9 +221,14 @@ def create_email_body(clean_data_frame, file_name: str) -> None:
     email_body_txt.append(f"Total active listings: {total_ads}")
     email_body_txt.append("")
 
-    for room_count in range(4):
-        room_count_str = str(room_count + 1)
-        section_line = str(room_count_str + " room apartment segment:")
+    if rc_column_dtype == 'int64':
+        unique_room_counts = sorted(clean_data_frame['Room_count'].unique())
+    else:
+        unique_room_counts = sorted(clean_data_frame['Room_count'].unique(), key=int)
+
+    for room_count_val in unique_room_counts:
+        room_count_str = str(room_count_val)
+        section_line = room_count_str + " room apartment segment:"
         email_body_txt.append(section_line)
         if rc_column_dtype == 'int64':
             filtered_by_room_count = clean_data_frame.loc[clean_data_frame['Room_count'] == int(


### PR DESCRIPTION
## Summary

**BUG-4** — `analytics.py:130`
`avg_price` was computed as `(min + max) / 2` — a midpoint, not a mean. For skewed distributions (e.g. the 3-room segment where one developer lists 8 units at 130k–179k while others list at 58k–90k) the midpoint overstates the average by a significant margin.

- Before: `avg_price = str((min(prices) + max(prices)) / 2)` → `118500.0` for 3-room segment
- After: `avg_price = str(round(sum(prices) / len(prices), 2))` → true mean

**BUG-5** — `df_cleaner.py:224`
`create_email_body()` iterated `range(4)`, hardcoding room counts 1–4. `analytics_main()` uses `split_dataframe_by_column()` which finds all unique values in the DataFrame — so 5-room (and any future 6+ room) apartments appeared in the summary stats table but had no detail rows in the listing section, creating a confusing inconsistency.

- Before: `for room_count in range(4):`
- After: derives `unique_room_counts` from the DataFrame itself, so listing segments always match the stats table

## Files changed
- `src/ws/app/wsmodules/analytics.py` — `calculate_price_stats()`
- `src/ws/app/wsmodules/df_cleaner.py` — `create_email_body()`

## Test plan
- [ ] Verify Avg Price in summary table matches true mean (not midpoint) for each segment
- [ ] Verify 5-room segment detail rows appear in next email report listing section
- [ ] Verify 1–4 room segments still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)