### PR TITLE
(fix): restore ValueError raise in validate_list_lengths to prevent silent data loss

### DIFF
--- a/src/ws/app/wsmodules/data_format_changer.py
+++ b/src/ws/app/wsmodules/data_format_changer.py
@@ -282,7 +282,7 @@ def validate_list_lengths(lists) -> None:
     if len(set(list_lengths)) > 1:
         error_message = f"All lists must have the same length. Found lengths: {list_lengths}"
         log.error(error_message)
-        # raise ValueError(error_message)
+        raise ValueError(error_message)
     log.info("Validation for all provided data element lists completed successfully")
 
 


### PR DESCRIPTION
## Summary
One-line fix: uncomment `raise ValueError(error_message)` in `data_format_changer.py:285`.

## Problem
`validate_list_lengths()` detected when scraped field counts mismatched (e.g. URL count ≠ price count due to a malformed entry in the raw scrape file), logged the error, but then silently continued. Execution fell through to `trim_lists_to_min_length()` which truncated all lists to the shortest one — dropping real ads from the report with no visible trace to the user.

The raise was explicitly documented in the function's docstring (`Raises: ValueError`) and was only commented out as a workaround at some point.

## Why it's safe to restore
The `ValueError` is raised inside the outer `try` block of `create_oneline_report()`. The existing `except Exception as e` at line 265 catches it, logs `"An error occurred while processing the file..."`, and the function returns `None`. The caller `cloud_data_formater_main()` already handles `None` at lines 136–138 with a logged error — no crash, no silent data corruption.

## Before / After
```
# Before — parsing error silently truncates data:
log.error("All lists must have the same length. Found lengths: [47, 47, 47, 47, 47, 47, 46]")
# execution continues, 1 ad silently dropped

# After — parsing error surfaces clearly:
log.error("All lists must have the same length. Found lengths: [47, 47, 47, 47, 47, 47, 46]")
raise ValueError(...)  # caught by outer except, logged, returns None
```

## Files changed
- `src/ws/app/wsmodules/data_format_changer.py:285`

## Test plan
- [ ] Verify normal runs (equal list lengths) complete without error
- [ ] Verify a malformed scrape file logs the mismatch error and returns None rather than silently dropping rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)