### PR TITLE
fix: close all logging handlers on shutdown to prevent file descriptor leaks

### DIFF
--- a/src/ws/app/main.py
+++ b/src/ws/app/main.py
@@ -11,6 +11,7 @@ This module contains functions:
 
 """
 
+import atexit
 from datetime import datetime
 import gc
 import logging
@@ -45,6 +46,23 @@ log.addHandler(ch)
 fh = handlers.RotatingFileHandler("ws_main.log", maxBytes=(1048576 * 5), backupCount=5)
 fh.setFormatter(fastapi_log_format)
 log.addHandler(fh)
+
+
+def cleanup_logging_handlers() -> None:
+    """Close and remove handlers for all loggers to release file descriptors on shutdown."""
+    all_loggers = [logging.root] + [
+        logging.getLogger(name) for name in logging.root.manager.loggerDict
+    ]
+    for logger in all_loggers:
+        for handler in logger.handlers[:]:
+            try:
+                handler.close()
+            except Exception:
+                pass
+            logger.removeHandler(handler)
+
+
+atexit.register(cleanup_logging_handlers)
 
 
 def log_memory_usage():


### PR DESCRIPTION
## Summary
- Adds `import atexit` to `main.py`
- Adds `cleanup_logging_handlers()` function that iterates over every logger in Python's logging registry (root + all named loggers) and calls `handler.close()` + `logger.removeHandler(handler)` on each
- Registers it with `atexit.register()` so it runs when the uvicorn worker process exits

## Why
Each of the 8 wsmodules (`analytics`, `aws_mailer`, `data_format_changer`, `df_cleaner`, `db_worker`, `file_downloader`, `pdf_creator`, `web_scraper`) registers a `StreamHandler` + `RotatingFileHandler` at import time. These file descriptors are never explicitly released when a uvicorn worker exits after hitting `--limit-max-requests`. Over many worker restarts the open file descriptors accumulate, contributing to the observed memory growth (245 MB → 1.7 GB over 3 months).

The cleanup targets all loggers in the registry so it covers the wsmodule loggers, not just `main.py`'s own logger.

## Test plan
- [ ] Deploy to staging and confirm service starts without errors
- [ ] Trigger `/run-task` and confirm log output is normal during the task
- [ ] Confirm worker restart (after `--limit-max-requests`) completes without file descriptor errors in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)