### PR TITLE
feat: EUR currency labels, unified date format, street abbreviation normalisation

### DIFF
--- a/src/ws/app/wsmodules/db_worker.py
+++ b/src/ws/app/wsmodules/db_worker.py
@@ -255,7 +255,7 @@ def compare_df_to_db_hashes(df_hashes: list, db_hashes: list) -> list:
         f"{len(removed_ads)} to_remove hashes "
     )
     today = datetime.today()
-    formatted_date = today.strftime("%Y-%m-%d")
+    formatted_date = today.strftime("%d.%m.%Y")
     todays_result = (
         f"{formatted_date}: Scraped today: {len(df_hashes)} | "
         f"In DB: {len(db_hashes)} | Unchanged: {len(existing_ads)} | "

--- a/src/ws/app/wsmodules/df_cleaner.py
+++ b/src/ws/app/wsmodules/df_cleaner.py
@@ -32,6 +32,7 @@ Modulel TODO tasks:
 from datetime import datetime
 import gc
 import logging
+import re
 from logging.handlers import RotatingFileHandler
 import os
 import sys
@@ -237,7 +238,7 @@ def create_email_body(clean_data_frame, file_name: str) -> None:
         if rc_column_dtype == 'object':
             filtered_by_room_count = clean_data_frame.loc[clean_data_frame['Room_count'] == str(
                 room_count_str)]
-        colum_line = "[Rooms, Floor, Size, Price, SQM Price, Apartment Street, Pub_date,  URL]"
+        colum_line = "[Rooms, Floor, Size, Price EUR, SQM Price EUR, Apartment Street, Pub_date,  URL]"
         email_body_txt.append(colum_line)
         for index, row in filtered_by_room_count.iterrows():
             url_str = row["URL"]
@@ -253,8 +254,8 @@ def create_email_body(clean_data_frame, file_name: str) -> None:
             report_line = "  " + str(rooms_str) + "     " + \
                           str(floor_str) + "    " + \
                           str(sqm_str) + "   " + \
-                          str(total_price) + "    " + \
-                          str(sqm_price) + "   " + \
+                          str(total_price) + " EUR    " + \
+                          str(sqm_price) + " EUR   " + \
                           str(street_str) + "   " + \
                           str(pub_date_str) + " " + \
                           str(url_str) + new_marker
@@ -336,6 +337,24 @@ def save_pub_dates_report_to(pubdates_out_file_name: str, month_data: list) -> N
         f"Completed writing {text_line_cnt} lines to {pubdates_out_file_name} file ")
 
 
+_STREET_ABBREVIATIONS = [
+    (r'\bpr\.\b', 'prospekts'),
+    (r'\biel\.\b', 'iela'),
+    (r'\bblv\.\b', 'bulvāris'),
+    (r'\bšos\.\b', 'šoseja'),
+]
+
+
+def normalise_street(street: str) -> str:
+    """Expand common Latvian street abbreviations to their full form."""
+    if not isinstance(street, str):
+        return street
+    result = street.strip()
+    for pattern, replacement in _STREET_ABBREVIATIONS:
+        result = re.sub(pattern, replacement, result, flags=re.IGNORECASE)
+    return result
+
+
 def df_cleaner_main():
     """ Cleans df, sorts df by price in EUR, save to csv file """
     log.info(" --- Started df_cleaner module ---")
@@ -352,6 +371,7 @@ def df_cleaner_main():
             clean_sqm_col = clean_sqm_column(clean_df)
             clean_price_col = split_price_column(clean_sqm_col)
             clean_df = clean_sqm_eur_col(clean_price_col)
+            clean_df['Street'] = clean_df['Street'].apply(normalise_street)
             sorted_df = clean_df.sort_values(by='Price_in_eur', ascending=True)
             sorted_df.to_csv("cleaned-sorted-df.csv")
             del raw_data_frame, clean_sqm_col, clean_price_col, clean_df, sorted_df


### PR DESCRIPTION
## Summary
- **UX-2**: Price and SQM price values in the email body now show `14000 EUR` and `280 EUR` instead of bare integers. Column header updated to match: `Price EUR` / `SQM Price EUR`.
- **UX-6**: DB sync log date format changed from `YYYY-MM-DD` to `DD.MM.YYYY` — all three sections of the email (apartment listings, DB sync log, month summary) now use the same format.
- **DQ-1**: New `normalise_street()` function in `df_cleaner.py` expands common Latvian street abbreviations before the cleaned CSV is written:
  - `pr.` → `prospekts`
  - `iel.` → `iela`
  - `blv.` → `bulvāris`
  - `šos.` → `šoseja`

  Applied to the `Street` column via `clean_df['Street'].apply(normalise_street)` in `df_cleaner_main()`.

## Test plan
- [ ] Deploy to staging and trigger `/run-task`
- [ ] Confirm email prices show `EUR` suffix
- [ ] Confirm DB sync log date shows `DD.MM.YYYY` format
- [ ] Confirm `Mālkalnes pr.` addresses expand to `Mālkalnes prospekts` in the report

🤖 Generated with [Claude Code](https://claude.com/claude-code)