### PR TITLE
feat: DQ-2 repeated address flag, CODE-2 shutil, CODE-3/4 guards, UX-5 tabulate

### DIFF
--- a/src/ws/app/wsmodules/data_format_changer.py
+++ b/src/ws/app/wsmodules/data_format_changer.py
@@ -34,6 +34,7 @@ Mudule creates:
 import gc
 import os
 import re
+import shutil
 from datetime import datetime
 import logging
 import logging.handlers as handlers
@@ -330,17 +331,15 @@ def create_file_copy() -> None:
     """
     todays_date = datetime.today().strftime('%Y-%m-%d')
     dest_file = 'pandas_df_' + todays_date + '.csv'
-    copy_cmd = 'cp pandas_df.csv data/' + dest_file
+    dest_path = os.path.join('data', dest_file)
     log.info("Creating backup of file: %s into folder 'data/'", dest_file)
 
     if not os.path.exists('data'):
         log.warning("'data' folder does not exist. Creating folder.")
         os.makedirs('data')
 
-    os.system(copy_cmd)
-    # log.info("Completed moving file: %s to folder 'data/' with success", dest_file)
+    shutil.copy2('pandas_df.csv', dest_path)
     try:
-        dest_path = './data/' + dest_file
         file_size = os.path.getsize(dest_path)
         log.info("Completed moving file: %s to folder 'data/' with success."
                  "File size: %d bytes", dest_file, file_size)

--- a/src/ws/app/wsmodules/df_cleaner.py
+++ b/src/ws/app/wsmodules/df_cleaner.py
@@ -34,8 +34,9 @@ import gc
 import logging
 from logging.handlers import RotatingFileHandler
 import os
+import shutil
 import sys
-# from tabulate import tabulate
+from tabulate import tabulate
 import pandas as pd
 
 
@@ -216,9 +217,7 @@ def create_email_body(clean_data_frame, file_name: str) -> None:
     total_ads = len(clean_data_frame)
 
     email_body_txt = []
-    # UX-1: report date header
     email_body_txt.append(f"=== Ogre Apartment Report — {today_str} ===")
-    # UX-7: total active listing count summary
     email_body_txt.append(f"Total active listings: {total_ads}")
     email_body_txt.append("")
 
@@ -227,38 +226,41 @@ def create_email_body(clean_data_frame, file_name: str) -> None:
     else:
         unique_room_counts = sorted(clean_data_frame['Room_count'].unique(), key=int)
 
+    headers = ['Rooms', 'Floor', 'Size', 'Price EUR', 'SQM EUR', 'Street', 'Date', 'URL']
+
     for room_count_val in unique_room_counts:
         room_count_str = str(room_count_val)
-        section_line = room_count_str + " room apartment segment:"
-        email_body_txt.append(section_line)
+        email_body_txt.append(room_count_str + " room apartment segment:")
         if rc_column_dtype == 'int64':
-            filtered_by_room_count = clean_data_frame.loc[clean_data_frame['Room_count'] == int(
-                room_count_str)]
-        if rc_column_dtype == 'object':
-            filtered_by_room_count = clean_data_frame.loc[clean_data_frame['Room_count'] == str(
-                room_count_str)]
-        colum_line = "[Rooms, Floor, Size, Price, SQM Price, Apartment Street, Pub_date,  URL]"
-        email_body_txt.append(colum_line)
-        for index, row in filtered_by_room_count.iterrows():
-            url_str = row["URL"]
-            sqm_str = row["Size_sqm"]
-            floor_str = row["Floor"]
-            total_price = row["Price_in_eur"]
-            sqm_price = row['SQ_meter_price']
-            rooms_str = row['Room_count']
-            street_str = row['Street']
-            pub_date_str = row['Pub_date']
-            # UX-3: mark listings published today
+            filtered_by_room_count = clean_data_frame.loc[
+                clean_data_frame['Room_count'] == int(room_count_str)]
+        else:
+            filtered_by_room_count = clean_data_frame.loc[
+                clean_data_frame['Room_count'] == str(room_count_str)]
+
+        # DQ-2: count listings per street within this segment
+        street_counts = filtered_by_room_count['Street'].value_counts()
+
+        table_rows = []
+        for _, row in filtered_by_room_count.iterrows():
+            street_str = str(row['Street'])
+            pub_date_str = str(row['Pub_date'])
             new_marker = " [NEW]" if pub_date_str == today_str else ""
-            report_line = "  " + str(rooms_str) + "     " + \
-                          str(floor_str) + "    " + \
-                          str(sqm_str) + "   " + \
-                          str(total_price) + "    " + \
-                          str(sqm_price) + "   " + \
-                          str(street_str) + "   " + \
-                          str(pub_date_str) + " " + \
-                          str(url_str) + new_marker
-            email_body_txt.append(report_line)
+            count = street_counts.get(street_str, 1)
+            street_display = f"{street_str} ({count} listings)" if count > 1 else street_str
+            table_rows.append([
+                str(row['Room_count']),
+                str(row['Floor']),
+                str(row['Size_sqm']),
+                f"{row['Price_in_eur']} EUR",
+                f"{row['SQ_meter_price']} EUR",
+                street_display,
+                pub_date_str + new_marker,
+                str(row['URL']),
+            ])
+        email_body_txt.append(tabulate(table_rows, headers=headers, tablefmt="simple"))
+        email_body_txt.append("")
+
     log.info(f"Completed creation of {file_name} file")
     save_text_report_to_file(email_body_txt, file_name)
 
@@ -399,10 +401,10 @@ def create_file_copy() -> None:
         "Started copy of cleaned-sorted-df-YYYY-MM-DD.csv in data folder")
     todays_date = datetime.today().strftime('%Y-%m-%d')
     dest_file = 'cleaned-sorted-df-' + todays_date + '.csv'
-    copy_cmd = 'cp cleaned-sorted-df.csv data/' + dest_file
+    dest_path = os.path.join('data', dest_file)
     if not os.path.exists('data'):
         os.makedirs('data')
-    os.system(copy_cmd)
+    shutil.copy2('cleaned-sorted-df.csv', dest_path)
     log.info(f"Completed creating file copy of {dest_file}")
 
 
@@ -412,11 +414,11 @@ def create_mb_file_copy() -> None:
         "Started copy of email_body_txt_m4-YYYY-MM-DD.txt in data folder")
     todays_date = datetime.today().strftime('%Y-%m-%d')
     dest_file = 'email_body_txt_m4-' + todays_date + '.txt'
-    copy_cmd = 'cp email_body_txt_m4.txt data/' + dest_file
+    dest_path = os.path.join('data', dest_file)
     if not os.path.exists('data'):
         os.makedirs('data')
-    os.system(copy_cmd)
-    log.info("Completed creating file copy of %s ",  dest_file)
+    shutil.copy2('email_body_txt_m4.txt', dest_path)
+    log.info("Completed creating file copy of %s", dest_file)
 
 
 if __name__ == "__main__":

--- a/src/ws/app/wsmodules/gen_report.py
+++ b/src/ws/app/wsmodules/gen_report.py
@@ -33,5 +33,6 @@ def gen_report(report_type: str, file_name: str, segments: list, images: list) -
     report.save_report('Ogre_daily.pdf')
 
 
-gen_report('Daily', 'Ogre_daily.pdf', segments, images)
+if __name__ == "__main__":
+    gen_report('Daily', 'Ogre_daily.pdf', segments, images)
 

--- a/src/ws/app/wsmodules/run_analisys.py
+++ b/src/ws/app/wsmodules/run_analisys.py
@@ -2,8 +2,6 @@
 
 import pandas as pd
 
-data_frame = pd.read_csv('cleaned-sorted-df.csv')
-
 #segments = [ 'room_stats.txt',
 #             'house_stats.txt',
 #             'apt_loc_stats.txt' ]
@@ -41,5 +39,6 @@ def gen_image(data_frame: pd.DataFrame, xclmn: str, yclmn: str) -> None:
     fig.savefig(file_name)
 
 
-run_analisys()
-
+if __name__ == "__main__":
+    data_frame = pd.read_csv('cleaned-sorted-df.csv')
+    run_analisys()


### PR DESCRIPTION
## Summary

Implements the final 4 items from `todo_refactor_email_report.md`.

- **DQ-2** — `df_cleaner.py:create_email_body()`: count listings per street within each room segment with `value_counts()`. When a street appears more than once, the street cell shows `Draudzības 6a (8 listings)` so the reader immediately knows they're looking at multiple units in the same building.
- **CODE-2** — `data_format_changer.py` + `df_cleaner.py`: replace all three `os.system('cp ...')` calls with `shutil.copy2()`. Removes shell injection risk and silent failure on non-Unix systems.
- **CODE-3/4** — `run_analisys.py` + `gen_report.py`: move the module-level `pd.read_csv()` and function calls inside `if __name__ == "__main__"` guards so importing either module no longer executes side-effects.
- **UX-5** — `df_cleaner.py:create_email_body()`: replace manual string concatenation rows with `tabulate(tablefmt="simple")` per segment. Column alignment now matches the price stats table in the analytics section. EUR labels and `[NEW]` marker are preserved.

## Note on merge order
This PR and #413 (UX-2/UX-6/DQ-1) both touch `create_email_body()`. Merge #413 first, then this PR — the `create_email_body()` rewrite here subsumes the EUR label change from #413 so the conflict resolution is straightforward (keep this version).

## Test plan
- [ ] Deploy to staging and trigger `/run-task`
- [ ] Confirm apartment listing table is column-aligned (tabulate simple format)
- [ ] Confirm streets with multiple listings show `(N listings)` annotation
- [ ] Confirm `data/` backup files are created correctly after switching to `shutil`
- [ ] Import `run_analisys` and `gen_report` in a REPL and confirm no side-effects fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)