### PR TITLE
bugfix: inject RELEASE_VERSION and APP_ENV into .env.prod (not .env)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,12 +96,18 @@ jobs:
             echo "=== Running setup ==="
             make setup
 
-            echo "=== Injecting version and environment into .env.prod ==="
+            echo "=== Injecting version and environment ==="
+            export RELEASE_VERSION="${RELEASE_VERSION}"
+            export APP_ENV="${APP_ENV}"
             sed -i '/^RELEASE_VERSION=/d; /^APP_ENV=/d' .env.prod
             echo "RELEASE_VERSION=${RELEASE_VERSION}" >> .env.prod
             echo "APP_ENV=${APP_ENV}" >> .env.prod
-            echo "Final injected values:"
+            echo "Shell env (what docker-compose actually uses):"
+            env | grep -E '^(RELEASE_VERSION|APP_ENV)='
+            echo ".env.prod values:"
             grep -E '^(RELEASE_VERSION|APP_ENV)=' .env.prod
+            echo "Resolved docker-compose config:"
+            docker compose --env-file .env.prod config | grep -E 'RELEASE_VERSION|APP_ENV' || true
 
             echo "=== Building containers ==="
             make build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -93,12 +93,15 @@ jobs:
             echo "=== Loading secrets ==="
             source ./scripts/load_secrets.sh
 
-            echo "=== Injecting version and environment ==="
-            echo "RELEASE_VERSION=${RELEASE_VERSION}" >> .env
-            echo "APP_ENV=${APP_ENV}" >> .env
-
             echo "=== Running setup ==="
             make setup
+
+            echo "=== Injecting version and environment into .env.prod ==="
+            sed -i '/^RELEASE_VERSION=/d; /^APP_ENV=/d' .env.prod
+            echo "RELEASE_VERSION=${RELEASE_VERSION}" >> .env.prod
+            echo "APP_ENV=${APP_ENV}" >> .env.prod
+            echo "Final injected values:"
+            grep -E '^(RELEASE_VERSION|APP_ENV)=' .env.prod
 
             echo "=== Building containers ==="
             make build

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -154,12 +154,18 @@ jobs:
             echo "=== Running setup ==="
             make setup
 
-            echo "=== Injecting version and environment into .env.prod ==="
+            echo "=== Injecting version and environment ==="
+            export RELEASE_VERSION="${RELEASE_VERSION}"
+            export APP_ENV="${APP_ENV}"
             sed -i '/^RELEASE_VERSION=/d; /^APP_ENV=/d' .env.prod
             echo "RELEASE_VERSION=${RELEASE_VERSION}" >> .env.prod
             echo "APP_ENV=${APP_ENV}" >> .env.prod
-            echo "Final injected values:"
+            echo "Shell env (what docker-compose actually uses):"
+            env | grep -E '^(RELEASE_VERSION|APP_ENV)='
+            echo ".env.prod values:"
             grep -E '^(RELEASE_VERSION|APP_ENV)=' .env.prod
+            echo "Resolved docker-compose config:"
+            docker compose --env-file .env.prod config | grep -E 'RELEASE_VERSION|APP_ENV' || true
 
             echo "=== Building containers ==="
             make build

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -151,12 +151,15 @@ jobs:
             echo "=== Loading secrets ==="
             source ./scripts/load_secrets.sh
 
-            echo "=== Injecting version and environment ==="
-            echo "RELEASE_VERSION=${RELEASE_VERSION}" >> .env
-            echo "APP_ENV=${APP_ENV}" >> .env
-
             echo "=== Running setup ==="
             make setup
+
+            echo "=== Injecting version and environment into .env.prod ==="
+            sed -i '/^RELEASE_VERSION=/d; /^APP_ENV=/d' .env.prod
+            echo "RELEASE_VERSION=${RELEASE_VERSION}" >> .env.prod
+            echo "APP_ENV=${APP_ENV}" >> .env.prod
+            echo "Final injected values:"
+            grep -E '^(RELEASE_VERSION|APP_ENV)=' .env.prod
 
             echo "=== Building containers ==="
             make build

--- a/scripts/load_secrets.sh
+++ b/scripts/load_secrets.sh
@@ -11,4 +11,3 @@ secret=$(aws secretsmanager get-secret-value --secret-id sslv_creds --query Secr
 export S3_BUCKET=$(echo $secret | jq -r '.s3_db_backups')
 export DEST_EMAIL=$(echo $secret | jq -r '.dest_email')
 export SRC_EMAIL=$(echo $secret | jq -r '.src_email')
-export RELEASE_VERSION=$(echo $secret | jq -r '.release_version')


### PR DESCRIPTION
## Bug
After PR #415 merged, the production email subject came out as:
`Ogre City Apartments for sale from ss.lv web_scraper_1.5.6_20260504_0040 []`

- `1.5.6` instead of the latest tag `v1.5.12` / `v1.5.13-rc`
- `[]` instead of `[production]` / `[staging]`

## Root cause
PR #415 wrote `RELEASE_VERSION` and `APP_ENV` into `.env`, but the Makefile uses `--env-file .env.prod` for both `make build` and `make up`. Our writes were ignored. docker-compose substituted whatever was in `.env.prod` (downloaded from S3): a stale `RELEASE_VERSION=1.5.6` and no `APP_ENV` (→ empty string).

Additionally, the injection ran BEFORE `make setup` — but `make setup` re-runs `load_secrets.sh`, which re-downloads `.env.prod` from S3 and would have wiped our changes anyway.

## Fix (CI-FIX-1 through CI-FIX-4 + CLEAN-1)
- **CI-FIX-1**: Change target from `.env` → `.env.prod` in both `main.yml` and `staging.yml`
- **CI-FIX-2**: Move injection AFTER `make setup` so it doesn't get overwritten
- **CI-FIX-3**: `sed -i` to strip any pre-existing `RELEASE_VERSION` / `APP_ENV` lines before appending, so the stale `1.5.6` in the S3 copy of `.env.prod` doesn't leak through
- **CI-FIX-4**: `grep` the injected values into the deploy log for verification
- **CLEAN-1**: Remove the stale `export RELEASE_VERSION=...` from `scripts/load_secrets.sh` — CI now owns this; the secret was pulling an outdated `1.5.6` from AWS Secrets Manager

## Recommended manual follow-up (not in this PR)
- **CLEAN-2**: Edit `s3://sslv-ws-m5-cicd-files/.env.prod` to remove the stale `RELEASE_VERSION=1.5.6` line (defensive `sed` already handles it, but cleaner to fix at source)
- **CLEAN-3**: Remove `release_version` key from the `sslv_creds` AWS Secrets Manager entry — no longer used after CLEAN-1

## Test plan
- [ ] Trigger `workflow_dispatch` on `staging.yml` against this branch and verify deploy log shows `RELEASE_VERSION=v1.5.13-rc` and `APP_ENV=staging` after the injection step
- [ ] Verify staging email subject contains `web_scraper_v1.5.13-rc_..._[staging]`
- [ ] After merge, push a trivial commit to `main` and verify production email subject contains `web_scraper_v<tag>_..._[production]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)