### PR TITLE
bugfix: aws_mailer correctness fixes (BUG-1..4 from todo_aws_mailer.md)

### DIFF
--- a/src/ws/app/wsmodules/aws_mailer.py
+++ b/src/ws/app/wsmodules/aws_mailer.py
@@ -64,7 +64,7 @@ def remove_tmp_files(files_to_remove: list) -> None:
             os.remove(file)
             log.info(f"File: {file} deleted with success ")
         except OSError as e:
-            log.error(f" {e.strerror} ")
+            log.error(f"Failed to delete {file}: {e}")
 
 
 def gen_subject_title() -> str:
@@ -156,14 +156,12 @@ def aws_mailer_main() -> None:
     """
     log.info("--- AWS SES mailer module started ---")
 
-    SENDER = "info@propertydata.lv"
-    RECIPIENT = "info@propertydata.lv"
+    SENDER = os.environ.get('SRC_EMAIL', 'info@propertydata.lv')
+    RECIPIENT = os.environ.get('DEST_EMAIL', 'info@propertydata.lv')
     AWS_REGION = "eu-west-1"  # e.g., Ireland
     SUBJECT = gen_subject_title()
-    # TEXT_SECTION_URLS = extract_file_contents("email_body_txt_m4.txt")
 
-    with open("email_body_txt_m4.txt", "r", encoding="utf-8") as f:
-        BODY_TEXT = f.read()
+    BODY_TEXT = extract_file_contents("email_body_txt_m4.txt")
 
     # List the files you want to append in order
     extra_files = [
@@ -211,10 +209,8 @@ def aws_mailer_main() -> None:
             Source=SENDER,
         )
     except ClientError as e:
-        print(f"Failed to send email: {e.response['Error']['Message']}")
         log.error(f"Failed to send email: {e.response['Error']['Message']}")
     else:
-        print(f"Email sent! Message ID: {response['MessageId']}")
         log.info(f"Email sent! Message ID: {response['MessageId']}")
     log.info("--- AWS SES mailer module completed with succeess ---")
     remove_tmp_files(data_files)


### PR DESCRIPTION
## Summary
First fix-PR off `todo_aws_mailer.md`. Four correctness bugs in `src/ws/app/wsmodules/aws_mailer.py`:

- **BUG-1**: `SENDER` / `RECIPIENT` were hardcoded — now read from `SRC_EMAIL` / `DEST_EMAIL` env vars (already plumbed through `docker-compose.yml` and `.env.prod`, just unused).
- **BUG-2** (+ resolves DEAD-1): unhandled `FileNotFoundError` on `email_body_txt_m4.txt` would crash the mailer silently if an upstream scrape step left the file missing. Replaced raw `open()` with `extract_file_contents()`, which already has the right error handling and was previously dead code.
- **BUG-3**: `remove_tmp_files` logged `e.strerror`, which is `None` for some `OSError` subclasses → useless `"  None  "` log lines. Now logs full exception + filename.
- **BUG-4**: every send result was both `print`ed AND logged; logger has a stdout `StreamHandler` so every message appeared twice in container logs. Dropped the `print` calls.

## Out of scope (deferred)
Per priority table in `todo_aws_mailer.md`, the following items go in follow-up PRs: RF-1 (region from env), RF-2/3/4/5, BUG-3 message details beyond what's here, all DOC-* and TYPO-* items, and DEAD-2 (unused `RotatingFileHandler` import).

## Test plan
- [ ] Local: `pytest tests/test_07_module_aws_mailer.py` passes (existing test imports `remove_tmp_files`; signature unchanged)
- [ ] Staging deploy: trigger and verify email is received and that subject still includes the version + `[staging]` tag (no regression from the recent versioning work)
- [ ] Staging deploy: confirm no duplicate "Email sent! Message ID..." lines in container logs
- [ ] If `email_body_txt_m4.txt` is missing in any run, the mailer should log a `FileNotFoundError` and still send a degraded email (with the fallback message extract_file_contents returns) — not crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)