### PR TITLE
chore: aws_mailer docs, typos, and trivial cleanup (follow-up to #419)

### DIFF
--- a/src/ws/app/wsmodules/aws_mailer.py
+++ b/src/ws/app/wsmodules/aws_mailer.py
@@ -1,25 +1,26 @@
 #!/usr/bin/env python3
 
-"""aws_mailer.py module
+"""Send the daily Ogre apartment scrape report via AWS SES.
 
-Main usage case for this module:
-    1. Send email using AWS SES service
-    3. Add ad oneline information about each apartment in email body
-    4. Use environemt varibales for source/destination email and API key
+Assembles the email body from text files produced by upstream pipeline
+modules (df_cleaner, db_worker, run_analisys), generates a dynamic
+subject line that includes release version and deployment environment,
+sends the message through AWS SES, and removes the scratch files.
 
-Tasks:
-[x] task 01 - test email is getting sent with success
-[x] task 02 - tmp files are deleted after email sent functionality
-[x] task 03 - dynamic email title functionality (city name, version, deploy date)
-[x] task 04 - email body contains adverts data for 1-6 room categories
-[x] task 05 - email body contains medatada/debug info
+Required environment variables:
+    SRC_EMAIL          Sender address (falls back to info@propertydata.lv)
+    DEST_EMAIL         Recipient address (falls back to info@propertydata.lv)
+    AWS_REGION         SES region (falls back to eu-west-1)
+    RELEASE_VERSION    Used in the email subject (falls back to 'unknown')
+    APP_ENV            Used in the email subject (falls back to 'local')
 
+AWS credentials must be available via the standard boto3 chain
+(instance profile, env vars, or ~/.aws/credentials).
 """
 
 from datetime import datetime
 import logging
 from logging import handlers
-from logging.handlers import RotatingFileHandler
 import sys
 import os
 import boto3
@@ -55,7 +56,15 @@ data_files = [
 
 
 def remove_tmp_files(files_to_remove: list) -> None:
-    """FIXME: Refactor this function to better code"""
+    """Best-effort delete of a list of temp files in the current working directory.
+
+    Per-file errors are logged but do not abort the loop — used post-send
+    to clean up scratch files left by upstream modules. Missing files are
+    treated as ordinary errors and logged at error level.
+
+    Args:
+        files_to_remove: List of filenames (relative to cwd) to delete.
+    """
     directory = os.getcwd()
     log.info(f"Attempting clean temp files from {directory} folder")
     for file in files_to_remove:
@@ -68,9 +77,17 @@ def remove_tmp_files(files_to_remove: list) -> None:
 
 
 def gen_subject_title() -> str:
-    """Function generates uniq subject line to improve debugging
-    Example of subject:
-    Ogre City Apartments for sale from ss.lv web_scraper_v1.5.12_20260502_1330 [production]"""
+    """Generate a unique email subject line tagged with version and environment.
+
+    The subject embeds the current timestamp, the deploy's RELEASE_VERSION
+    env var (or 'unknown' if unset), and the APP_ENV env var (or 'local'
+    if unset) in square brackets — making it trivial to identify which
+    deploy produced which email.
+
+    Returns:
+        A subject string of the form
+        "Ogre City Apartments for sale from ss.lv web_scraper_<version>_<YYYYMMDD>_<HHMM> [<env>]".
+    """
     log.info("Generating email subject with todays date")
     release = os.environ.get('RELEASE_VERSION', 'unknown')
     app_env = os.environ.get('APP_ENV', 'local')
@@ -158,7 +175,7 @@ def aws_mailer_main() -> None:
 
     SENDER = os.environ.get('SRC_EMAIL', 'info@propertydata.lv')
     RECIPIENT = os.environ.get('DEST_EMAIL', 'info@propertydata.lv')
-    AWS_REGION = "eu-west-1"  # e.g., Ireland
+    AWS_REGION = os.environ.get('AWS_REGION', 'eu-west-1')
     SUBJECT = gen_subject_title()
 
     BODY_TEXT = extract_file_contents("email_body_txt_m4.txt")
@@ -183,10 +200,10 @@ def aws_mailer_main() -> None:
 
     CHARSET = "UTF-8"
 
-    log.info("Creating AWS SES clinet using boto3 ")
+    log.info("Creating AWS SES client using boto3")
     client = boto3.client("ses", region_name=AWS_REGION)
 
-    log.info("Trying to sent email with AWS SES clinet using boto3 ")
+    log.info("Trying to send email with AWS SES client using boto3")
     try:
         response = client.send_email(
             Destination={
@@ -212,7 +229,7 @@ def aws_mailer_main() -> None:
         log.error(f"Failed to send email: {e.response['Error']['Message']}")
     else:
         log.info(f"Email sent! Message ID: {response['MessageId']}")
-    log.info("--- AWS SES mailer module completed with succeess ---")
+    log.info("--- AWS SES mailer module completed with success ---")
     remove_tmp_files(data_files)
 
 

--- a/todo_aws_mailer.md
+++ b/todo_aws_mailer.md
@@ -1,0 +1,94 @@
+# aws_mailer.py — Review & Action Items
+
+Generated: 2026-05-09
+File: `src/ws/app/wsmodules/aws_mailer.py`
+
+---
+
+## Status
+
+| PR | Scope | Items | Status |
+|---|---|---|---|
+| #419 | Correctness bugs | BUG-1, BUG-2 (+ DEAD-1), BUG-3, BUG-4 | Open |
+| #TBD | Docs / typos / cleanup | DOC-1, DOC-2, DOC-3, TYPO-1, TYPO-2, TYPO-3, DEAD-2, RF-1 | Open |
+| Future | Architectural cleanup | RF-2, RF-3, RF-4, RF-5 | Deferred |
+
+---
+
+## Done
+
+### BUG-1: SENDER/RECIPIENT from env (PR #419)
+Replaced hardcoded `info@propertydata.lv` literals with `os.environ.get('SRC_EMAIL', ...)` and `os.environ.get('DEST_EMAIL', ...)`. Env vars were already plumbed through `docker-compose.yml` and `.env.prod`, just unused.
+
+### BUG-2: Crash on missing `email_body_txt_m4.txt` (PR #419)
+Replaced raw `with open(...)` with `extract_file_contents()` which already has the right error handling. Side effect: resolves DEAD-1 (function is now actually called).
+
+### BUG-3: `e.strerror` can be `None` (PR #419)
+Changed `log.error(f" {e.strerror} ")` to `log.error(f"Failed to delete {file}: {e}")` — full exception always renders, includes the filename being processed.
+
+### BUG-4: Duplicate stdout output (PR #419)
+Removed `print()` calls; the logger's `StreamHandler(sys.stdout)` already covers stdout, so each result was appearing twice in container logs.
+
+### DEAD-1: `extract_file_contents` was unused (PR #419)
+Resolved as a side effect of BUG-2 — the function is now called for the main email body.
+
+### DOC-1: Module docstring rewrite (this PR)
+Replaced the broken task list (which skipped task 2 and contained typos) with a one-paragraph purpose summary and a list of required env vars with their fallbacks.
+
+### DOC-2: `remove_tmp_files` docstring (this PR)
+Replaced `"""FIXME: Refactor this function to better code"""` with a descriptive PEP-257-style docstring including Args section.
+
+### DOC-3: `gen_subject_title` docstring (this PR)
+Added Returns section documenting the subject string format. Cleaned up the prose.
+
+### TYPO-1: Module docstring typos (this PR)
+`environemt`, `varibales`, `medatada` — all gone with the docstring rewrite.
+
+### TYPO-2: Log string typos (this PR)
+- `"Creating AWS SES clinet using boto3 "` → `"Creating AWS SES client using boto3"`
+- `"Trying to sent email with AWS SES clinet using boto3 "` → `"Trying to send email with AWS SES client using boto3"`
+- `"--- AWS SES mailer module completed with succeess ---"` → `"--- AWS SES mailer module completed with success ---"`
+
+### TYPO-3: Module docstring task list numbering (this PR)
+Resolved by DOC-1 — the broken task list is gone.
+
+### DEAD-2: Unused `RotatingFileHandler` import (this PR)
+Removed `from logging.handlers import RotatingFileHandler` — `RotatingFileHandler` is referenced via `handlers.RotatingFileHandler`, the unqualified name was never used.
+
+### RF-1: AWS region from env (this PR)
+`AWS_REGION = "eu-west-1"  # e.g., Ireland` → `AWS_REGION = os.environ.get('AWS_REGION', 'eu-west-1')`.
+
+---
+
+## Remaining (deferred to future PR)
+
+### RF-2: Module-level logging handler setup
+**Lines 30-42 (current state)**: handlers are attached at import time. Multiple imports → multiple handlers → file-descriptor leak. Currently mitigated by the `atexit` cleanup in `main.py` that walks all loggers, so not urgent.
+
+**Fix**: move handler setup into a `_configure_logging()` function called once from `aws_mailer_main()`, gated by a "configured" flag.
+
+### RF-3: Log file path is cwd-dependent
+**Line 39 (current state)**: `RotatingFileHandler("aws_mailer.log", ...)` — relative path. If cwd changes between callers, the log lands in different directories or fails silently.
+
+**Fix**: anchor to a known location, e.g. `os.path.join(os.path.dirname(__file__), '..', 'logs', 'aws_mailer.log')`, or make it env-driven.
+
+### RF-4: Hardcoded filename lists drift
+The module-level `data_files` and the in-function `extra_files` overlap (`basic_price_stats.txt`, `email_body_add_dates_table.txt` appear in both). Two sources of truth for "what files this module touches" — easy to drift when new files are added by `df_cleaner.py` or `db_worker.py`.
+
+**Fix**: consolidate into one list, or generate from a glob pattern.
+
+### RF-5: Bare `except Exception` in `extract_file_contents`
+**Lines 138-144 (current state)**: catches everything, returns a friendly string. Hides bugs (e.g. encoding errors, permission issues) by masking them as "file not found".
+
+**Fix**: catch only the specific exceptions expected (`UnicodeDecodeError`, `PermissionError`); let the rest propagate.
+
+---
+
+## Future-PR priority
+
+| Priority | ID | Item | Effort | Reason |
+|---|---|---|---|---|
+| 1 | RF-3 | Anchor log file path | 3 lines | Same anti-pattern across project; surfaces silently |
+| 2 | RF-5 | Narrow `except Exception` in `extract_file_contents` | 3 lines | Hides real bugs |
+| 3 | RF-4 | Consolidate filename lists | 5 lines | Drift risk; not breaking |
+| 4 | RF-2 | Move logging setup into a function | ~10 lines | Already mitigated by `main.py` atexit cleanup |


### PR DESCRIPTION
## Summary
Follow-up to PR #419 (correctness fixes). Picks up the docs/typos/cleanup half of `todo_aws_mailer.md`.

**Targets `bugfix/aws-mailer-bugs` so the diff layers cleanly on top of #419.** When #419 merges to `main`, GitHub will auto-rebase this onto `main`.

### Changes
| ID | Change |
|---|---|
| **DOC-1** | Module docstring rewritten — replaces a broken task list (skipped task 2 + typos) with a purpose summary and required-env-vars list |
| **DOC-2** | `remove_tmp_files` docstring — replaces `"""FIXME: Refactor this function to better code"""` with a PEP-257 docstring |
| **DOC-3** | `gen_subject_title` — added Returns section with the exact subject string format |
| **TYPO-1** | Module docstring typos (`environemt`, `varibales`, `medatada`) gone with DOC-1 |
| **TYPO-2** | Log strings: `clinet` → `client` (twice), `succeess` → `success`, `to sent email` → `to send email` |
| **TYPO-3** | Broken task numbering gone with DOC-1 |
| **DEAD-2** | Removed unused `from logging.handlers import RotatingFileHandler` |
| **RF-1** | `AWS_REGION` now `os.environ.get('AWS_REGION', 'eu-west-1')` — same anti-pattern as the SENDER/RECIPIENT fix in #419 |

### Out of scope
RF-2 (module-level handler setup), RF-3 (cwd-relative log path), RF-4 (overlapping filename lists), RF-5 (bare `except Exception`) — collected into the future-PR priority table in `todo_aws_mailer.md`.

### Test plan
- [ ] `pytest tests/test_07_module_aws_mailer.py` — only docstrings/strings touched, signatures unchanged
- [ ] Staging deploy: confirm subject line format unchanged (regression check on the recent versioning work)
- [ ] Inspect container logs: no `clinet`/`succeess` typos remain; success/failure lines appear once each

🤖 Generated with [Claude Code](https://claude.com/claude-code)