### PR TITLE
bugfix: pin Secrets Manager calls to eu-west-1 (unblocks eu-north-1 staging)

### DIFF
--- a/scripts/get_last_s3_file.sh
+++ b/scripts/get_last_s3_file.sh
@@ -1,12 +1,17 @@
 #!/bin/bash
 
+# Secrets Manager is region-scoped; sslv_creds lives in eu-west-1.
+# Override AWS_RES_REGION if the secret moves.
+AWS_RES_REGION="${AWS_RES_REGION:-eu-west-1}"
+
 # Set your S3 bucket name
-secret=$(aws secretsmanager get-secret-value --secret-id sslv_creds --query SecretString --output text)
+secret=$(aws --region "$AWS_RES_REGION" secretsmanager get-secret-value \
+    --secret-id sslv_creds --query SecretString --output text)
 S3_BUCKET=$(echo $secret | jq -r '.s3_db_backups')
 
 # Fetch the latest uploaded file from the S3 bucket using AWS CLI
 # We use the `aws s3api` to list objects sorted by LastModified date, in descending order.
-LATEST_FILE=$(aws s3api list-objects-v2 --bucket "$S3_BUCKET" --query 'Contents | sort_by(@, &LastModified)[-1].Key' --output text)
+LATEST_FILE=$(aws --region "$AWS_RES_REGION" s3api list-objects-v2 --bucket "$S3_BUCKET" --query 'Contents | sort_by(@, &LastModified)[-1].Key' --output text)
 
 # Check if the file was found
 if [ -z "$LATEST_FILE" ]; then
@@ -16,7 +21,7 @@ fi
 
 # Download the latest file to the current directory
 echo "Downloading latest file: $LATEST_FILE from S3 bucket: $S3_BUCKET"
-aws s3 cp "s3://$S3_BUCKET/$LATEST_FILE" .
+aws --region "$AWS_RES_REGION" s3 cp "s3://$S3_BUCKET/$LATEST_FILE" .
 
 # Check if the download was successful
 if [ $? -eq 0 ]; then

--- a/scripts/load_secrets.sh
+++ b/scripts/load_secrets.sh
@@ -1,11 +1,17 @@
 #!/bin/bash
 
+# All AWS resources (S3 bucket + sslv_creds secret) live in eu-west-1.
+# Pin the region explicitly so this script works from any EC2 region —
+# Secrets Manager is region-scoped and won't auto-redirect like S3 does.
+AWS_RES_REGION="${AWS_RES_REGION:-eu-west-1}"
+
 # Download env files
-aws s3 cp s3://sslv-ws-m5-cicd-files/.env.prod .
-aws s3 cp s3://sslv-ws-m5-cicd-files/database.ini .
+aws --region "$AWS_RES_REGION" s3 cp s3://sslv-ws-m5-cicd-files/.env.prod .
+aws --region "$AWS_RES_REGION" s3 cp s3://sslv-ws-m5-cicd-files/database.ini .
 
 # Fetch the secret from Secrets Manager
-secret=$(aws secretsmanager get-secret-value --secret-id sslv_creds --query SecretString --output text)
+secret=$(aws --region "$AWS_RES_REGION" secretsmanager get-secret-value \
+    --secret-id sslv_creds --query SecretString --output text)
 
 # Parse the JSON to get individual values
 export S3_BUCKET=$(echo $secret | jq -r '.s3_db_backups')

--- a/scripts/set_s3_env_from_aws_sm.sh
+++ b/scripts/set_s3_env_from_aws_sm.sh
@@ -1,8 +1,13 @@
 
 #!/bin/bash
 
+# Secrets Manager is region-scoped; sslv_creds lives in eu-west-1.
+# Override AWS_RES_REGION if the secret moves.
+AWS_RES_REGION="${AWS_RES_REGION:-eu-west-1}"
+
 # Fetch secret
-secret=$(aws secretsmanager get-secret-value --secret-id sslv_creds --query SecretString --output text)
+secret=$(aws --region "$AWS_RES_REGION" secretsmanager get-secret-value \
+    --secret-id sslv_creds --query SecretString --output text)
 
 if [ $? -ne 0 ]; then
   echo "❌ Failed to fetch secret"


### PR DESCRIPTION
## Bug
When the staging EC2 was moved to `eu-north-1` (to escape ss.lv's IP block on AWS Ireland), `make setup` started failing with:
```
An error occurred (ResourceNotFoundException) when calling the GetSecretValue operation: Secrets Manager can't find the specified secret.
```

## Root cause
AWS Secrets Manager is **region-scoped**. The `sslv_creds` secret physically lives in `eu-west-1`. Without `--region`, the AWS CLI inherits the EC2's region from instance metadata, so the call went to the eu-north-1 Secrets Manager endpoint where the secret doesn't exist.

S3 worked fine in the same script because the CLI **auto-redirects** S3 calls to the bucket's home region — Secrets Manager has no such behavior.

## Fix
Pin both `secretsmanager` callers to `eu-west-1`, with an `AWS_RES_REGION` env override for future migrations:

- `scripts/load_secrets.sh` — pinned both the S3 calls and the secretsmanager call (S3 doesn't strictly need it, but keeping all resource calls in one region makes the locality obvious)
- `scripts/set_s3_env_from_aws_sm.sh` — same pin for the secretsmanager call

## Why not replicate the secret to eu-north-1?
Considered, but ruled out: keeping two copies of `sslv_creds` invites drift on rotation. Single source of truth in eu-west-1 is cleaner; the staging EC2 just reads cross-region.

## Test plan
- [x] `gh workflow run staging.yml -f branch=bugfix/secrets-manager-cross-region` against the eu-north-1 staging EC2 — verify `make setup` completes (no ResourceNotFoundException)
- [x] Verify the email arrives with the correct version + `[staging]` tag (regression check on PR #416)
- [ ] After merge, also verify production deploy from eu-west-1 still works (no behavior change there since the default region matches)

## IAM note
The instance profile `VF-Custom-S3-SecretsManager-access` must allow `secretsmanager:GetSecretValue` on the eu-west-1 ARN. If staging deploy still gets `AccessDenied` after this PR, the IAM policy needs to either widen its resource ARN or be region-agnostic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)