### PR TITLE
chore: silence xargs noise on fresh EC2 container cleanup

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,8 +80,8 @@ jobs:
             set -e
             echo "=== Stopping old containers ==="
             docker ps
-            docker ps -aq | xargs docker rm -f || true
-            docker images -q | xargs docker rmi -f || true
+            docker ps -aq | xargs -r docker rm -f || true
+            docker images -q | xargs -r docker rmi -f || true
             echo "=== Old containers stopped ==="
 
             echo "=== Cloning repository ==="

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -135,8 +135,8 @@ jobs:
             set -e
             echo "=== Stopping old containers ==="
             docker ps
-            docker ps -aq | xargs docker rm -f || true
-            docker images -q | xargs docker rmi -f || true
+            docker ps -aq | xargs -r docker rm -f || true
+            docker images -q | xargs -r docker rmi -f || true
             echo "=== Old containers stopped ==="
 
             echo "=== Cloning repository ==="


### PR DESCRIPTION
## Why
On a fresh EC2 (e.g. the new eu-north-1 staging instance), the deploy log starts with two scary-looking errors:

```
"docker rm" requires at least 1 argument.
"docker rmi" requires at least 1 argument.
```

These are not real failures — `|| true` already swallows the exit code — but they're confusing when triaging deploy logs.

## Cause
`docker ps -aq` outputs nothing when there are no containers, but `xargs` still invokes `docker rm -f` with zero arguments, and `docker rm` errors out.

## Fix
Add `-r` (GNU xargs alias for `--no-run-if-empty`) so xargs skips the invocation entirely when stdin is empty:

```bash
docker ps -aq | xargs -r docker rm -f || true
docker images -q | xargs -r docker rmi -f || true
```

Kept the trailing `|| true` so legitimate failures (e.g. a stuck container) on non-empty cleanup still don't abort the deploy — preserving prior intent.

## Test plan
- [ ] Trigger a staging deploy on an EC2 with no containers — log should now go straight from `docker ps` (empty header) to `=== Old containers stopped ===` without the xargs error spam
- [ ] Trigger a staging deploy on an EC2 WITH existing containers — should still tear them down and continue the deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)